### PR TITLE
[XPU][Membar] Define basic Intel-specific `Membar` filter

### DIFF
--- a/third_party/intel/include/Analysis/Membar.h
+++ b/third_party/intel/include/Analysis/Membar.h
@@ -1,0 +1,16 @@
+#ifndef TRITON_INTEL_ANALYSIS_MEMBAR_H
+#define TRITON_INTEL_ANALYSIS_MEMBAR_H
+
+namespace mlir {
+class Operation;
+namespace intel {
+/// Intel-specific callback to filter operations that need no barriers between
+/// each other.
+///
+/// This is useful as the granularity to check whether barriers are needed is
+/// quite coarse.
+bool membarFilter(Operation *lhsOp, Operation *rhsOp);
+} // namespace intel
+} // namespace mlir
+
+#endif // TRITON_INTEL_ANALYSIS_MEMBAR_H

--- a/third_party/intel/lib/Analysis/CMakeLists.txt
+++ b/third_party/intel/lib/Analysis/CMakeLists.txt
@@ -3,6 +3,7 @@ add_triton_library(TritonIntelAnalysis
     AxisInfo.cpp
     DPAS.cpp
     Liveness.cpp
+    Membar.cpp
     Utility.cpp
 
     DEPENDS

--- a/third_party/intel/lib/Analysis/Membar.cpp
+++ b/third_party/intel/lib/Analysis/Membar.cpp
@@ -1,0 +1,58 @@
+#include "intel/include/Analysis/Membar.h"
+
+#include "intel/include/Analysis/Utility.h"
+
+namespace mlir::intel {
+namespace {
+triton::gpu::ConvertLayoutOp dynCastToSubGroupTranspose(Operation *op) {
+  auto convertLayout = dyn_cast<triton::gpu::ConvertLayoutOp>(op);
+  if (!convertLayout)
+    return nullptr;
+
+  if (!triton::gpu::intel::cvtIsSubGroupTranspose(
+          convertLayout.getSrc().getType(),
+          convertLayout.getResult().getType()))
+    return nullptr;
+
+  return convertLayout;
+}
+
+/// Check if `lhsOp` and `rhsOp` are safe to overlap sub-group transpose-like
+/// layout conversions.
+///
+/// Sub-group transposes are implemented as follows:
+///
+/// - Each sub-group writes all the elements it is handling in a memory block
+/// - Each sub-group reads all the elements it is handling from the same memory
+/// region.
+///
+/// As there is no need to synchronize work-items in the same sub-group and we
+/// know data won't be shared between sub-groups, it is safe to overlap these
+/// operations.
+bool areSafeToOverlapSubGroupTransposeOps(Operation *lhsOp, Operation *rhsOp) {
+  // Check both are lowered to sub-group transpose operations.
+  auto lhsTranspose = dynCastToSubGroupTranspose(lhsOp);
+  if (!lhsTranspose)
+    return false;
+  auto rhsTranspose = dynCastToSubGroupTranspose(rhsOp);
+  if (!rhsTranspose)
+    return false;
+
+  // Check the types of source and result are the same, i.e., we are expressing
+  // the same kind of transposition.
+  if (lhsTranspose.getSrc().getType() != lhsTranspose.getSrc().getType() ||
+      lhsTranspose.getResult().getType() != lhsTranspose.getResult().getType())
+    return false;
+
+  // Check both have the same offset and thus these operation can be overlapped.
+  return lhsTranspose->getAttr("allocation.offset") ==
+         rhsTranspose->getAttr("allocation.offset");
+}
+} // namespace
+bool membarFilter(Operation *lhsOp, Operation *rhsOp) {
+  // For now, we only check these aren't layout conversions implemented as the
+  // same sub-group transposition.
+  assert(lhsOp && rhsOp && "Expecting valid operations");
+  return areSafeToOverlapSubGroupTransposeOps(lhsOp, rhsOp);
+}
+} // namespace mlir::intel


### PR DESCRIPTION
Define Intel-specific `Membar` filter to reduce synchronization overhead in the Intel backend.

`Membar` analysis will insert barriers to avoid race conditions between operations accessing the same memory. The granularity of this analysis is a bit coarse, tho, and unneeded barriers may be inserted. In order to avoid this, the analysis allows users to pass a callback function to filter safe cases.

As one of the recurring cases of barriers being inserted when not needed, detect back to back layout conversions implemented as sub-group transposes as safe so no barriers are inserted.

See code for further details on why this is safe.
